### PR TITLE
minor changes

### DIFF
--- a/src/app/components/sdrf-editor/sdrf-editor.component.ts
+++ b/src/app/components/sdrf-editor/sdrf-editor.component.ts
@@ -337,7 +337,9 @@ const BUFFER_ROWS = 10;
               <div class="validation-panel-header">
                 <div class="validation-title">
                   <h3>SDRF Validation</h3>
-                  @if (pyodideState() === 'loading') {
+                  @if (usingApiFallback()) {
+                    <span class="pyodide-status api-fallback" title="Using EBI PRIDE SDRF Validator API">API</span>
+                  } @else if (pyodideState() === 'loading') {
                     <span class="pyodide-status loading">{{ pyodideLoadProgress() }}</span>
                   } @else if (pyodideState() === 'ready') {
                     <span class="pyodide-status ready">Ready</span>
@@ -371,6 +373,8 @@ const BUFFER_ROWS = 10;
                   >
                     @if (pyodideValidating()) {
                       <span class="spinner-sm"></span> Validating...
+                    } @else if (usingApiFallback()) {
+                      Validate (API)
                     } @else if (pyodideState() === 'not-loaded') {
                       Load & Validate
                     } @else {
@@ -1163,6 +1167,7 @@ const BUFFER_ROWS = 10;
     .pyodide-status.loading { background: #fef3c7; color: #92400e; }
     .pyodide-status.ready { background: #d1fae5; color: #059669; }
     .pyodide-status.error { background: #fee2e2; color: #b91c1c; }
+    .pyodide-status.api-fallback { background: #dbeafe; color: #1e40af; }
 
     .validation-panel-body {
       padding: 12px 16px;
@@ -1786,6 +1791,10 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
   pyodideAvailableTemplates = computed(() => this.pyodideService.availableTemplates());
   pyodideErrorCount = computed(() => this.pyodideErrors().filter(e => e.level === 'error').length);
   pyodideWarningCount = computed(() => this.pyodideErrors().filter(e => e.level === 'warning').length);
+
+  /** API fallback state */
+  usingApiFallback = computed(() => this.pyodideService.usingApiFallback());
+  apiAvailable = computed(() => this.pyodideService.apiAvailable());
 
   /** Context menu state */
   contextMenu = signal<{ x: number; y: number; row: number; col: number } | null>(null);

--- a/src/app/components/sdrf-recommend-panel/sdrf-recommend-panel.component.ts
+++ b/src/app/components/sdrf-recommend-panel/sdrf-recommend-panel.component.ts
@@ -2044,6 +2044,8 @@ export class SdrfRecommendPanelComponent implements OnChanges, AfterViewInit {
   readonly pyodideLoadProgress = computed(() => this.pyodideService.loadProgress());
   readonly pyodideAvailableTemplates = computed(() => this.pyodideService.availableTemplates());
   readonly pyodideErrorCount = computed(() => this.pyodideErrors().filter(e => e.level === 'error').length);
+  readonly usingApiFallback = computed(() => this.pyodideService.usingApiFallback());
+  readonly apiAvailable = computed(() => this.pyodideService.apiAvailable());
   readonly pyodideWarningCount = computed(() => this.pyodideErrors().filter(e => e.level === 'warning').length);
   readonly pyodideLastError = computed(() => this.pyodideService.lastError());
 

--- a/src/app/core/services/sdrf-api-validator.service.ts
+++ b/src/app/core/services/sdrf-api-validator.service.ts
@@ -1,0 +1,270 @@
+/**
+ * SDRF API Validator Service
+ *
+ * Provides SDRF validation using the EBI PRIDE SDRF Validator API.
+ * This is used as a fallback when Pyodide-based validation fails.
+ *
+ * API Documentation: https://www.ebi.ac.uk/pride/services/sdrf-validator/docs
+ */
+
+import { signal } from '@angular/core';
+import { ValidationError } from './pyodide-validator.service';
+
+/**
+ * API validation error from the SDRF Validator API
+ */
+export interface ApiValidationError {
+  message: string;
+  error_type: string;
+  row?: number;
+  column?: string;
+  value?: string;
+}
+
+/**
+ * API validation result from the SDRF Validator API
+ */
+export interface ApiValidationResult {
+  valid: boolean;
+  errors: ApiValidationError[];
+  warnings: ApiValidationError[];
+  error_count: number;
+  warning_count: number;
+  templates_used: string[];
+  sdrf_pipelines_version: string;
+}
+
+/**
+ * API templates response
+ */
+export interface ApiTemplatesResponse {
+  templates: string[];
+  legacy_mappings: Record<string, string>;
+}
+
+/**
+ * API health response
+ */
+export interface ApiHealthResponse {
+  status: string;
+  sdrf_pipelines_version: string;
+  ontology_validation_available: boolean;
+}
+
+const API_BASE_URL = 'https://www.ebi.ac.uk/pride/services/sdrf-validator';
+
+export class SdrfApiValidatorService {
+  readonly isAvailable = signal<boolean | null>(null);
+  readonly lastError = signal<string | null>(null);
+  readonly apiVersion = signal<string | null>(null);
+
+  /**
+   * Check if the API is available and healthy
+   */
+  async checkHealth(): Promise<boolean> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/health`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        this.isAvailable.set(false);
+        return false;
+      }
+
+      const health: ApiHealthResponse = await response.json();
+      this.isAvailable.set(health.status === 'healthy');
+      this.apiVersion.set(health.sdrf_pipelines_version);
+      return health.status === 'healthy';
+    } catch (error) {
+      console.warn('SDRF API health check failed:', error);
+      this.isAvailable.set(false);
+      this.lastError.set(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+  }
+
+  /**
+   * Get available validation templates from the API
+   */
+  async getTemplates(): Promise<string[]> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/templates`, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to get templates: ${response.status}`);
+      }
+
+      const result: ApiTemplatesResponse = await response.json();
+      return result.templates;
+    } catch (error) {
+      console.warn('Failed to get templates from API:', error);
+      // Return default templates
+      return ['default', 'human', 'vertebrates', 'nonvertebrates', 'plants', 'cell_lines'];
+    }
+  }
+
+  /**
+   * Validate SDRF content using the API
+   *
+   * @param sdrfTsv - The SDRF content as TSV text
+   * @param templates - Templates to validate against
+   * @param options - Validation options
+   * @returns Array of validation errors
+   */
+  async validate(
+    sdrfTsv: string,
+    templates: string[] = ['default'],
+    options: { skipOntology?: boolean; useOlsCacheOnly?: boolean } = {}
+  ): Promise<ValidationError[]> {
+    const { skipOntology = true, useOlsCacheOnly = true } = options;
+
+    try {
+      // Build query parameters
+      const params = new URLSearchParams();
+      params.append('content', sdrfTsv);
+      templates.forEach(t => params.append('template', t));
+      params.append('skip_ontology', String(skipOntology));
+      params.append('use_ols_cache_only', String(useOlsCacheOnly));
+
+      const response = await fetch(`${API_BASE_URL}/validate/text?${params.toString()}`, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Validation API error: ${response.status} - ${errorText}`);
+      }
+
+      const result: ApiValidationResult = await response.json();
+
+      // Convert API errors to our ValidationError format
+      const errors = this.convertApiErrors(result.errors, 'error');
+      const warnings = this.convertApiErrors(result.warnings, 'warning');
+
+      return [...errors, ...warnings];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.lastError.set(errorMessage);
+      throw new Error(`SDRF API validation failed: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Validate SDRF file using multipart upload
+   *
+   * @param file - The SDRF file to validate
+   * @param templates - Templates to validate against
+   * @param options - Validation options
+   * @returns Array of validation errors
+   */
+  async validateFile(
+    file: File,
+    templates: string[] = ['default'],
+    options: { skipOntology?: boolean; useOlsCacheOnly?: boolean } = {}
+  ): Promise<ValidationError[]> {
+    const { skipOntology = true, useOlsCacheOnly = true } = options;
+
+    try {
+      // Build query parameters
+      const params = new URLSearchParams();
+      templates.forEach(t => params.append('template', t));
+      params.append('skip_ontology', String(skipOntology));
+      params.append('use_ols_cache_only', String(useOlsCacheOnly));
+
+      // Create form data with file
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const response = await fetch(`${API_BASE_URL}/validate?${params.toString()}`, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+        },
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Validation API error: ${response.status} - ${errorText}`);
+      }
+
+      const result: ApiValidationResult = await response.json();
+
+      // Convert API errors to our ValidationError format
+      const errors = this.convertApiErrors(result.errors, 'error');
+      const warnings = this.convertApiErrors(result.warnings, 'warning');
+
+      return [...errors, ...warnings];
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.lastError.set(errorMessage);
+      throw new Error(`SDRF API validation failed: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Convert API error format to our internal ValidationError format
+   */
+  private convertApiErrors(
+    apiErrors: ApiValidationError[],
+    level: 'error' | 'warning'
+  ): ValidationError[] {
+    return apiErrors.map(err => ({
+      message: err.message,
+      row: err.row ?? -1,
+      column: err.column ?? null,
+      value: err.value ?? null,
+      level,
+      suggestion: this.generateSuggestion(err),
+    }));
+  }
+
+  /**
+   * Generate a suggestion based on the error type
+   */
+  private generateSuggestion(error: ApiValidationError): string | null {
+    const errorType = error.error_type?.toLowerCase() || '';
+    const message = error.message?.toLowerCase() || '';
+
+    // Common error patterns and suggestions
+    if (errorType.includes('missing') || message.includes('missing')) {
+      if (error.column) {
+        return `Add a value for the "${error.column}" column`;
+      }
+      return 'Add the missing required value';
+    }
+
+    if (errorType.includes('ontology') || message.includes('ontology')) {
+      return 'Use a valid ontology term from the appropriate ontology (e.g., EFO, NCBI Taxonomy)';
+    }
+
+    if (errorType.includes('format') || message.includes('format')) {
+      return 'Check the value format and ensure it matches the expected pattern';
+    }
+
+    if (errorType.includes('duplicate') || message.includes('duplicate')) {
+      return 'Remove or rename duplicate entries';
+    }
+
+    if (message.includes('not allowed') || message.includes('invalid')) {
+      return 'Check the allowed values for this column';
+    }
+
+    return null;
+  }
+}
+
+// Export singleton instance
+export const sdrfApiValidatorService = new SdrfApiValidatorService();


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add API fallback mechanism when Pyodide validation fails

- Create new SDRF API Validator Service for EBI PRIDE API integration

- Display API fallback status in validation panel UI

- Update validation logic to gracefully degrade to API when needed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PyodideInit["Pyodide Initialization"] -->|fails| CheckAPI["Check API Health"]
  CheckAPI -->|available| UseFallback["Use API Fallback"]
  CheckAPI -->|unavailable| Error["Throw Error"]
  Validate["Validate SDRF"] -->|Pyodide ready| PyodideVal["Pyodide Validation"]
  Validate -->|Pyodide unavailable| APIVal["API Validation"]
  PyodideVal -->|fails| APIVal
  APIVal -->|success| Results["Return Results"]
  PyodideVal -->|success| Results
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sdrf-editor.component.ts</strong><dd><code>Add API fallback UI indicators and state signals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/sdrf-editor/sdrf-editor.component.ts

<ul><li>Add conditional rendering for API fallback status badge in validation <br>panel header<br> <li> Display "API" status indicator when using API fallback with tooltip<br> <li> Update validation button text to show "Validate (API)" when using <br>fallback<br> <li> Add CSS styling for api-fallback status badge with blue color scheme<br> <li> Add computed signals for <code>usingApiFallback()</code> and <code>apiAvailable()</code> state</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrfedit/pull/12/files#diff-53a86085545ccc4ee240bb9812ee0f4f70659e0e2e713896d8aff94d6ae8008b">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdrf-recommend-panel.component.ts</strong><dd><code>Add API fallback state signals to component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/components/sdrf-recommend-panel/sdrf-recommend-panel.component.ts

<ul><li>Add computed signals for <code>usingApiFallback()</code> and <code>apiAvailable()</code> from <br>pyodide service<br> <li> Expose API fallback state for use in recommendation panel template</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrfedit/pull/12/files#diff-e89d7497bb5ffc516701b619b74414d8e0957fb9e8bb90589caaf618b71a06b0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyodide-validator.service.ts</strong><dd><code>Implement API fallback logic in Pyodide validator service</code></dd></summary>
<hr>

src/app/core/services/pyodide-validator.service.ts

<ul><li>Import and integrate <code>SdrfApiValidatorService</code> for fallback validation<br> <li> Add <code>usingApiFallback</code> and <code>apiAvailable</code> signal states<br> <li> Update <code>isReady</code> computed to return true when using API fallback<br> <li> Implement API fallback logic in <code>initialize()</code> method with health checks<br> <li> Add fallback validation in <code>loadTemplates()</code> to fetch from API if <br>Pyodide fails<br> <li> Refactor <code>validate()</code> method to attempt API fallback on Pyodide failure<br> <li> Add new <code>validateWithApiFallback()</code> private method for API validation <br>attempts<br> <li> Add comprehensive console logging for fallback state transitions</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrfedit/pull/12/files#diff-4281d9dba867970797ac449689ade71685cd9df605ea9bbbf7a15c97615287b9">+124/-12</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdrf-api-validator.service.ts</strong><dd><code>Create new SDRF API Validator Service for fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/core/services/sdrf-api-validator.service.ts

<ul><li>Create new service class for EBI PRIDE SDRF Validator API integration<br> <li> Implement <code>checkHealth()</code> method to verify API availability<br> <li> Implement <code>getTemplates()</code> method to fetch available validation <br>templates<br> <li> Implement <code>validate()</code> method for text-based SDRF validation with query <br>parameters<br> <li> Implement <code>validateFile()</code> method for multipart file upload validation<br> <li> Add error conversion from API format to internal <code>ValidationError</code> <br>format<br> <li> Add intelligent suggestion generation based on error types<br> <li> Export singleton instance <code>sdrfApiValidatorService</code> for application-wide <br>use<br> <li> Define TypeScript interfaces for API responses and error structures</ul>


</details>


  </td>
  <td><a href="https://github.com/bigbio/sdrfedit/pull/12/files#diff-24ca1c20e9873c1c98a606fe451228b2e8b53c7130ad780bfd23b7797549bb8e">+270/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic API fallback support for validation when the primary method becomes unavailable
  * Status indicators now display when API fallback is active in the editor header
  * Enhanced validation flow with improved health checks and error handling
  * Seamless fallback mechanism ensures continuous validation service availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->