### PR TITLE
Docs: point to bigbio/sdrf-annotated-datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ If you have a collection of annotated SDRF files, you can build a local knowledg
 # Provide paths to directories containing .sdrf.tsv files
 node scripts/build-sdrf-index.js /path/to/your/sdrf-files /another/path
 
-# Or use the public proteomics-metadata-standard repository
-git clone https://github.com/bigbio/proteomics-metadata-standard.git
-node scripts/build-sdrf-index.js ./proteomics-metadata-standard/annotated-projects
+# Or use the public bigbio/sdrf-annotated-datasets repository
+git clone https://github.com/bigbio/sdrf-annotated-datasets.git
+node scripts/build-sdrf-index.js ./sdrf-annotated-datasets/datasets
 ```
 
 ### Using a Config File
@@ -206,7 +206,7 @@ For repeated builds, create a config file:
 ```json
 {
   "paths": [
-    "../proteomics-metadata-standard/annotated-projects",
+    "../sdrf-annotated-datasets/datasets",
     "./my-local-sdrf-collection"
   ]
 }

--- a/scripts/build-sdrf-index.js
+++ b/scripts/build-sdrf-index.js
@@ -326,7 +326,7 @@ function getPaths() {
     console.error('  node scripts/build-sdrf-index.js <path1> [path2] ...');
     console.error('  node scripts/build-sdrf-index.js --config ./paths.json\n');
     console.error('Example:');
-    console.error('  node scripts/build-sdrf-index.js ../proteomics-metadata-standard/annotated-projects');
+    console.error('  node scripts/build-sdrf-index.js ../sdrf-annotated-datasets/datasets');
     process.exit(1);
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -51,8 +51,8 @@ export class AppComponent implements OnInit {
   activeUrl = '';
   activeContent = '';
 
-  // Example SDRF from proteomics-metadata-standard
-  readonly exampleUrl = 'https://raw.githubusercontent.com/bigbio/proteomics-metadata-standard/master/annotated-projects/PXD000070/PXD000070.sdrf.tsv';
+  // Example SDRF from bigbio/sdrf-annotated-datasets
+  readonly exampleUrl = 'https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000070/PXD000070.sdrf.tsv';
 
   ngOnInit(): void {
     // Check for URL parameter to auto-load SDRF file


### PR DESCRIPTION
## Summary
- annotated SDRFs moved from `bigbio/proteomics-metadata-standard/annotated-projects/` to `bigbio/sdrf-annotated-datasets/datasets/{ACCESSION}/`
- repoint README knowledge-base examples, `exampleUrl` in `src/app/app.component.ts`, and the usage string in `scripts/build-sdrf-index.js` to the new repo and `datasets/` layout
- `dist/` not rebuilt here; will be regenerated at the next release

## Related
- New repo: https://github.com/bigbio/sdrf-annotated-datasets
- Migration discussion: https://github.com/bigbio/proteomics-sample-metadata/issues/817

## Test plan
- [ ] `grep -R annotated-projects src/ scripts/ README.md` returns nothing
- [ ] example URL `https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000070/PXD000070.sdrf.tsv` loads successfully in the editor
- [ ] `node scripts/build-sdrf-index.js ../sdrf-annotated-datasets/datasets` builds an index when the sibling repo is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example dataset source references to point to a new upstream repository, including documentation and sample configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->