### PR TITLE
Prefer the PRIDE SDRF validator API in the editor

### DIFF
--- a/src/app/components/sdrf-editor/sdrf-editor.component.ts
+++ b/src/app/components/sdrf-editor/sdrf-editor.component.ts
@@ -47,6 +47,7 @@ import { SdrfRecommendation } from '../../core/models/llm';
 import {
   PyodideValidatorService,
   pyodideValidatorService,
+  ValidationBackendMode,
   ValidationError,
 } from '../../core/services/pyodide-validator.service';
 import { sdrfExport } from '../../core/services/sdrf-export.service';
@@ -360,17 +361,19 @@ const BUFFER_ROWS = 10;
             <button class="btn btn-small" (click)="jumpToRow()">Go</button>
           </div>
 
-          <!-- Validation Panel (Pyodide-based) -->
+          <!-- Validation Panel -->
           @if (showValidationPanel()) {
             <div class="validation-panel-container">
               <div class="validation-panel-header">
                 <div class="validation-title">
                   <h3>SDRF Validation</h3>
-                  @if (usingApiFallback()) {
-                    <span class="pyodide-status api-fallback" title="Using EBI PRIDE SDRF Validator API">API</span>
-                  } @else if (pyodideState() === 'loading') {
+                  @if (validationMode() === 'api' && pyodideState() === 'loading') {
                     <span class="pyodide-status loading">{{ pyodideLoadProgress() }}</span>
-                  } @else if (pyodideState() === 'ready') {
+                  } @else if (validationMode() === 'api' && usingApiFallback()) {
+                    <span class="pyodide-status api-fallback" title="Using EBI PRIDE SDRF Validator API">API</span>
+                  } @else if (validationMode() === 'local' && pyodideState() === 'loading') {
+                    <span class="pyodide-status loading">{{ pyodideLoadProgress() }}</span>
+                  } @else if (validationMode() === 'local' && pyodideState() === 'ready') {
                     <span class="pyodide-status ready">Ready</span>
                   } @else if (pyodideState() === 'error') {
                     <span class="pyodide-status error">Error</span>
@@ -380,6 +383,35 @@ const BUFFER_ROWS = 10;
               </div>
 
               <div class="validation-panel-body">
+                <div class="validation-backend-row">
+                  <span class="template-label">Backend:</span>
+                  <label class="backend-option" [class.selected]="validationMode() === 'api'">
+                    <input
+                      type="radio"
+                      name="validation-backend"
+                      [checked]="validationMode() === 'api'"
+                      (change)="switchValidationMode('api')"
+                    />
+                    PRIDE API
+                  </label>
+                  <label class="backend-option" [class.selected]="validationMode() === 'local'">
+                    <input
+                      type="radio"
+                      name="validation-backend"
+                      [checked]="validationMode() === 'local'"
+                      (change)="switchValidationMode('local')"
+                    />
+                    Local browser
+                  </label>
+                  <span class="validation-backend-hint">
+                    @if (validationMode() === 'api') {
+                      Sends the current SDRF to PRIDE's deployed validator service.
+                    } @else {
+                      Runs the local sdrf-pipelines validator in the browser and keeps the SDRF on this device.
+                    }
+                  </span>
+                </div>
+
                 <!-- Template Selector: only show templates from library/API when loaded -->
                 <div class="template-selector-row">
                   <span class="template-label">Templates:</span>
@@ -398,8 +430,10 @@ const BUFFER_ROWS = 10;
                     </div>
                   } @else if (pyodideState() === 'loading') {
                     <span class="template-loading">Loading templates...</span>
-                  } @else if (pyodideState() === 'not-loaded') {
-                    <span class="template-loading">Load validator to see templates</span>
+                  } @else if (validationMode() === 'local' && pyodideState() === 'not-loaded') {
+                    <span class="template-loading">Load the local validator to see templates</span>
+                  } @else if (validationMode() === 'api' && !usingApiFallback()) {
+                    <span class="template-loading">Connect to the PRIDE API to load templates</span>
                   } @else if (pyodideState() === 'error') {
                     <span class="template-loading">Templates unavailable</span>
                   } @else {
@@ -412,12 +446,12 @@ const BUFFER_ROWS = 10;
                   >
                     @if (pyodideValidating()) {
                       <span class="spinner-sm"></span> Validating...
-                    } @else if (usingApiFallback()) {
-                      Validate (API)
+                    } @else if (validationMode() === 'api') {
+                      Validate via API
                     } @else if (pyodideState() === 'not-loaded') {
-                      Load & Validate
+                      Load Local Validator & Validate
                     } @else {
-                      Validate
+                      Validate Locally
                     }
                   </button>
                 </div>
@@ -1589,6 +1623,43 @@ const BUFFER_ROWS = 10;
       flex: 1;
     }
 
+    .validation-backend-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+    }
+
+    .backend-option {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      background: white;
+      border: 1px solid #d1d5db;
+      border-radius: 16px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .backend-option.selected {
+      background: #e0f2fe;
+      border-color: #0284c7;
+      color: #0f4c81;
+    }
+
+    .backend-option input {
+      margin: 0;
+    }
+
+    .validation-backend-hint {
+      font-size: 12px;
+      color: #4b5563;
+      flex: 1 1 320px;
+    }
+
     .template-selector-row {
       display: flex;
       align-items: center;
@@ -2301,6 +2372,9 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
   /** Selected templates for validation */
   selectedTemplates = signal<string[]>(['ms-proteomics']);
 
+  /** Active validation backend */
+  validationMode = signal<ValidationBackendMode>('api');
+
   /** Aggregated validation errors (grouped by message) */
   aggregatedErrors = computed(() => this.aggregateErrors(this.pyodideErrors()));
 
@@ -2547,11 +2621,14 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
   }
 
   /**
-   * Initialize Pyodide runtime
+   * Initialize the selected validation backend and load its templates.
    */
-  async initPyodide(): Promise<void> {
+  async initPyodide(mode: ValidationBackendMode = this.validationMode()): Promise<void> {
     try {
-      await this.pyodideService.initialize();
+      await this.pyodideService.initialize({
+        mode,
+        allowApiFallback: mode === 'auto',
+      });
 
       const available = this.pyodideAvailableTemplates();
       if (available.length === 0) return;
@@ -2569,19 +2646,37 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
         this.selectedTemplates.set(current.length > 0 ? current : [fallback]);
       }
     } catch (err) {
-      console.error('Failed to initialize Pyodide:', err);
+      console.error('Failed to initialize validation backend:', err);
     }
   }
 
   /**
-   * Run Pyodide validation
+   * Switch between API-backed and local validation.
+   */
+  async switchValidationMode(mode: ValidationBackendMode): Promise<void> {
+    if (this.validationMode() === mode) {
+      return;
+    }
+
+    this.validationMode.set(mode);
+    this.pyodideErrors.set([]);
+    this.pyodideHasValidated.set(false);
+    await this.initPyodide(mode);
+  }
+
+  /**
+   * Run validation using the selected backend.
    */
   async runPyodideValidation(): Promise<void> {
     if (!this.table() || this.pyodideValidating()) return;
+    const mode = this.validationMode();
 
-    // Initialize Pyodide if not ready
-    if (!this.pyodideIsReady()) {
-      await this.initPyodide();
+    // Initialize the selected backend if needed
+    if (
+      (mode === 'api' && !this.usingApiFallback()) ||
+      (mode === 'local' && this.pyodideState() !== 'ready')
+    ) {
+      await this.initPyodide(mode);
     }
 
     this.pyodideValidating.set(true);
@@ -2614,7 +2709,11 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
       const errors = await this.pyodideService.validate(
         tsvContent,
         templatesToUse,
-        { skipOntology: true }
+        {
+          skipOntology: true,
+          mode,
+          allowApiFallback: false,
+        }
       );
 
       this.pyodideErrors.set(errors);

--- a/src/app/core/services/pyodide-validator.service.ts
+++ b/src/app/core/services/pyodide-validator.service.ts
@@ -4,7 +4,7 @@
  * Provides sdrf-pipelines validation by running Python code in the browser
  * via Pyodide (WebAssembly). Uses a Web Worker to avoid blocking the UI.
  *
- * Falls back to the EBI PRIDE SDRF Validator API when Pyodide fails.
+ * Also supports the EBI PRIDE SDRF Validator API as a remote validation backend.
  */
 
 import { Injectable, signal, computed } from '@angular/core';
@@ -46,10 +46,23 @@ export interface TemplateDetails {
  * Service state
  */
 export type PyodideState = 'not-loaded' | 'loading' | 'ready' | 'error';
+export type ValidationBackendMode = 'api' | 'local' | 'auto';
+
+interface ValidatorInitializeOptions {
+  mode?: ValidationBackendMode;
+  allowApiFallback?: boolean;
+}
+
+interface ValidatorRunOptions {
+  skipOntology?: boolean;
+  mode?: ValidationBackendMode;
+  allowApiFallback?: boolean;
+}
 
 @Injectable({ providedIn: 'root' })
 export class PyodideValidatorService {
   private worker: Worker | null = null;
+  private localValidatorReady = false;
   private messageId = 0;
   private pendingRequests = new Map<number, {
     resolve: (value: any) => void;
@@ -74,226 +87,102 @@ export class PyodideValidatorService {
   readonly isLoading = computed(() => this.state() === 'loading');
 
   /**
-   * Initialize Pyodide runtime.
-   * This downloads ~15MB on first load (cached afterwards).
+   * Initialize the requested validation backend.
+   * Local mode downloads and loads Pyodide in the browser.
+   * API mode checks the deployed PRIDE validator service and loads templates from it.
    */
-  async initialize(): Promise<void> {
-    if (this.state() === 'ready') {
-      return; // Already initialized
+  async initialize(options: ValidatorInitializeOptions = {}): Promise<void> {
+    const mode = options.mode ?? 'api';
+    const allowApiFallback =
+      options.allowApiFallback ?? (mode === 'auto');
+
+    if (mode === 'api') {
+      await this.initializeApiMode();
+      return;
     }
 
-    if (this.state() === 'loading') {
-      // Wait for existing initialization
-      return new Promise((resolve, reject) => {
-        const checkReady = setInterval(() => {
-          if (this.state() === 'ready') {
-            clearInterval(checkReady);
-            resolve();
-          } else if (this.state() === 'error') {
-            clearInterval(checkReady);
-            reject(new Error(this.lastError() || 'Initialization failed'));
-          }
-        }, 100);
-      });
-    }
-
-    this.state.set('loading');
-    this.loadProgress.set('Creating worker...');
-    this.lastError.set(null);
-
-    try {
-      // Create Web Worker
-      this.worker = new Worker(
-        new URL('../../workers/pyodide.worker', import.meta.url),
-        { type: 'module' }
-      );
-
-      // Set up message handler
-      this.worker.onmessage = (event) => this.handleWorkerMessage(event);
-      this.worker.onerror = (error) => this.handleWorkerError(error);
-
-      // Wait for Pyodide to be ready
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('Pyodide initialization timed out (60s)'));
-        }, 60000);
-
-        const readyHandler = (event: MessageEvent) => {
-          const { type, payload } = event.data;
-
-          if (type === 'progress') {
-            this.loadProgress.set(payload);
-          } else if (type === 'ready') {
-            clearTimeout(timeout);
-            this.worker?.removeEventListener('message', readyHandler);
-            resolve();
-          } else if (type === 'error') {
-            clearTimeout(timeout);
-            this.worker?.removeEventListener('message', readyHandler);
-            reject(new Error(payload));
-          }
-        };
-
-        this.worker?.addEventListener('message', readyHandler);
-        this.worker?.postMessage({ type: 'init' });
-      });
-
-      this.state.set('ready');
-      this.loadProgress.set('Ready');
-
-      // Load available templates
-      await this.loadTemplates();
-
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      console.warn('Pyodide initialization failed:', errorMessage);
-
-      // Try to fall back to API
-      console.log('Attempting to use SDRF Validator API as fallback...');
-      this.loadProgress.set('Pyodide failed, checking API...');
-
+    if (mode === 'auto') {
       try {
-        const apiHealthy = await this.apiValidator.checkHealth();
-        this.apiAvailable.set(apiHealthy);
-
-        if (apiHealthy) {
-          console.log('SDRF Validator API is available, using as fallback');
-          this.usingApiFallback.set(true);
-          this.state.set('not-loaded'); // Keep state as not-loaded but fallback is active
-          this.loadProgress.set('Using SDRF Validator API (Pyodide unavailable)');
-          this.lastError.set(`Pyodide failed: ${errorMessage}. Using API fallback.`);
-
-          // Load templates from API
-          const templates = await this.apiValidator.getTemplates();
-          this.availableTemplates.set(templates);
-
-          // Don't throw - we have a working fallback
-          return;
-        }
+        await this.initializeApiMode();
+        return;
       } catch (apiError) {
-        console.warn('API fallback also failed:', apiError);
+        console.warn('API initialization failed, trying local validator:', apiError);
+        await this.initializeLocalMode({ allowApiFallback });
+        return;
       }
-
-      // Both Pyodide and API failed
-      this.state.set('error');
-      this.lastError.set(errorMessage);
-      this.loadProgress.set(`Error: ${errorMessage}`);
-      throw error;
     }
+
+    await this.initializeLocalMode({ allowApiFallback });
   }
 
   /**
-   * Load list of available templates from sdrf-pipelines or API
+   * Load list of available templates from the selected backend
    */
-  private async loadTemplates(): Promise<void> {
-    // If using API fallback, get templates from API
-    if (this.usingApiFallback()) {
-      try {
-        const templates = await this.apiValidator.getTemplates();
-        this.availableTemplates.set(templates);
-        return;
-      } catch (error) {
-        console.warn('Failed to load templates from API:', error);
-      }
-    }
-
-    // Try Pyodide
-    try {
-      const templates = await this.sendMessage<string[]>('get-templates', {});
+  private async loadTemplates(mode: 'api' | 'local'): Promise<void> {
+    if (mode === 'api') {
+      const templates = await this.apiValidator.getTemplates();
       this.availableTemplates.set(templates);
-    } catch (error) {
-      console.warn('Failed to load templates from Pyodide:', error);
-
-      // Try API fallback
-      try {
-        const templates = await this.apiValidator.getTemplates();
-        this.availableTemplates.set(templates);
-        return;
-      } catch (apiError) {
-        console.warn('Failed to load templates from API:', apiError);
-      }
-
-      // Do not set fake templates - leave empty until library or API provides them
+      return;
     }
+
+    const templates = await this.sendMessage<string[]>('get-templates', {});
+    this.availableTemplates.set(templates);
   }
 
   /**
    * Validate SDRF content against specified templates.
-   * Falls back to API if Pyodide is not available.
    */
   async validate(
     sdrfTsv: string,
     templates: string[],
-    options: { skipOntology?: boolean } = {}
+    options: ValidatorRunOptions = {}
   ): Promise<ValidationError[]> {
-    // If using API fallback, validate via API
-    if (this.usingApiFallback()) {
-      console.log('Using API fallback for validation');
-      return this.apiValidator.validate(sdrfTsv, templates, {
-        skipOntology: options.skipOntology ?? true,
-      });
+    const mode = options.mode ?? 'api';
+    const allowApiFallback =
+      options.allowApiFallback ?? (mode === 'auto');
+
+    if (mode === 'api') {
+      return this.validateWithApi(sdrfTsv, templates, options);
     }
 
-    // If Pyodide is not ready, try API fallback
-    if (!this.isReady()) {
-      console.log('Pyodide not ready, attempting API fallback');
-      return this.validateWithApiFallback(sdrfTsv, templates, options);
+    if (mode === 'auto') {
+      try {
+        return await this.validateWithApi(sdrfTsv, templates, options);
+      } catch (apiError) {
+        console.warn('API validation failed, trying local validator:', apiError);
+        return this.validateLocally(sdrfTsv, templates, options, allowApiFallback);
+      }
     }
 
-    // Try Pyodide validation first
-    try {
-      const errors = await this.sendMessage<ValidationError[]>('validate', {
-        sdrf: sdrfTsv,
-        templates,
-        skipOntology: options.skipOntology ?? true
-      });
-
-      return errors;
-    } catch (error) {
-      // Pyodide validation failed, try API fallback
-      console.warn('Pyodide validation failed, falling back to API:', error);
-      return this.validateWithApiFallback(sdrfTsv, templates, options);
-    }
+    return this.validateLocally(sdrfTsv, templates, options, allowApiFallback);
   }
 
   /**
    * Validate using the API as a fallback
    */
-  private async validateWithApiFallback(
+  private async validateWithApi(
     sdrfTsv: string,
     templates: string[],
-    options: { skipOntology?: boolean } = {}
+    options: ValidatorRunOptions = {}
   ): Promise<ValidationError[]> {
-    try {
-      // Check if API is available
-      const apiHealthy = await this.apiValidator.checkHealth();
-      this.apiAvailable.set(apiHealthy);
+    await this.ensureApiAvailable();
 
-      if (!apiHealthy) {
-        throw new Error('SDRF Validator API is not available');
-      }
+    console.log('Using SDRF Validator API for validation');
+    this.loadProgress.set('Using SDRF Validator API...');
 
-      console.log('Using SDRF Validator API for validation');
-      this.loadProgress.set('Using SDRF Validator API...');
+    const errors = await this.apiValidator.validate(sdrfTsv, templates, {
+      skipOntology: options.skipOntology ?? true,
+    });
 
-      const errors = await this.apiValidator.validate(sdrfTsv, templates, {
-        skipOntology: options.skipOntology ?? true,
-      });
-
-      this.loadProgress.set('Validation complete (via API)');
-      return errors;
-    } catch (apiError) {
-      const errorMessage = apiError instanceof Error ? apiError.message : String(apiError);
-      this.lastError.set(`Validation failed: ${errorMessage}`);
-      throw new Error(`Both Pyodide and API validation failed: ${errorMessage}`);
-    }
+    this.loadProgress.set('Validation complete (via API)');
+    return errors;
   }
 
   /**
    * Get details about a specific template
    */
   async getTemplateDetails(templateName: string): Promise<TemplateDetails | null> {
-    if (!this.isReady()) {
+    if (this.usingApiFallback() || this.state() !== 'ready') {
       throw new Error('Pyodide not initialized. Call initialize() first.');
     }
 
@@ -322,7 +211,7 @@ export class PyodideValidatorService {
       content.includes('drosophila') ||
       content.includes('caenorhabditis')
     ) {
-      templates.push('nonvertebrates');
+      templates.push('invertebrates');
     } else if (
       content.includes('arabidopsis') ||
       content.includes('zea mays')
@@ -335,7 +224,7 @@ export class PyodideValidatorService {
       content.includes('characteristics[cell line]') ||
       content.includes('cvcl_')
     ) {
-      templates.push('cell_lines');
+      templates.push('cell-lines');
     }
 
     return templates;
@@ -405,6 +294,7 @@ export class PyodideValidatorService {
    */
   private handleWorkerError(error: ErrorEvent): void {
     console.error('Pyodide worker error:', error);
+    this.localValidatorReady = false;
     this.lastError.set(error.message || 'Unknown worker error');
     this.state.set('error');
   }
@@ -417,8 +307,167 @@ export class PyodideValidatorService {
       this.worker.terminate();
       this.worker = null;
     }
+    this.localValidatorReady = false;
+    this.usingApiFallback.set(false);
+    this.apiAvailable.set(null);
+    this.availableTemplates.set([]);
     this.state.set('not-loaded');
     this.pendingRequests.clear();
+  }
+
+  private async initializeApiMode(): Promise<void> {
+    this.state.set('loading');
+    this.usingApiFallback.set(false);
+    this.lastError.set(null);
+    this.loadProgress.set('Checking SDRF Validator API...');
+
+    try {
+      await this.ensureApiAvailable();
+      this.usingApiFallback.set(true);
+      this.state.set(this.localValidatorReady ? 'ready' : 'not-loaded');
+      this.loadProgress.set('Using SDRF Validator API');
+      await this.loadTemplates('api');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.state.set('error');
+      this.lastError.set(errorMessage);
+      this.loadProgress.set(`Error: ${errorMessage}`);
+      throw error;
+    }
+  }
+
+  private async initializeLocalMode(
+    options: { allowApiFallback?: boolean } = {}
+  ): Promise<void> {
+    const allowApiFallback = options.allowApiFallback ?? false;
+
+    if (this.localValidatorReady) {
+      this.usingApiFallback.set(false);
+      this.state.set('ready');
+      this.loadProgress.set('Ready');
+      await this.loadTemplates('local');
+      return;
+    }
+
+    if (this.state() === 'loading' && !this.usingApiFallback()) {
+      return this.waitForLocalInitialization();
+    }
+
+    this.usingApiFallback.set(false);
+    this.state.set('loading');
+    this.loadProgress.set('Creating worker...');
+    this.lastError.set(null);
+
+    try {
+      if (!this.worker) {
+        this.worker = new Worker(
+          new URL('../../workers/pyodide.worker', import.meta.url),
+          { type: 'module' }
+        );
+
+        this.worker.onmessage = (event) => this.handleWorkerMessage(event);
+        this.worker.onerror = (error) => this.handleWorkerError(error);
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Pyodide initialization timed out (60s)'));
+        }, 60000);
+
+        const readyHandler = (event: MessageEvent) => {
+          const { type, payload } = event.data;
+
+          if (type === 'progress') {
+            this.loadProgress.set(payload);
+          } else if (type === 'ready') {
+            clearTimeout(timeout);
+            this.worker?.removeEventListener('message', readyHandler);
+            resolve();
+          } else if (type === 'error') {
+            clearTimeout(timeout);
+            this.worker?.removeEventListener('message', readyHandler);
+            reject(new Error(payload));
+          }
+        };
+
+        this.worker?.addEventListener('message', readyHandler);
+        this.worker?.postMessage({ type: 'init' });
+      });
+
+      this.state.set('ready');
+      this.localValidatorReady = true;
+      this.loadProgress.set('Ready');
+      await this.loadTemplates('local');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn('Pyodide initialization failed:', errorMessage);
+      this.localValidatorReady = false;
+
+      if (allowApiFallback) {
+        console.log('Attempting to use SDRF Validator API as fallback...');
+        try {
+          await this.initializeApiMode();
+          this.lastError.set(`Pyodide failed: ${errorMessage}. Using API fallback.`);
+          return;
+        } catch (apiError) {
+          console.warn('API fallback also failed:', apiError);
+        }
+      }
+
+      this.state.set('error');
+      this.lastError.set(errorMessage);
+      this.loadProgress.set(`Error: ${errorMessage}`);
+      throw error;
+    }
+  }
+
+  private async validateLocally(
+    sdrfTsv: string,
+    templates: string[],
+    options: ValidatorRunOptions,
+    allowApiFallback: boolean
+  ): Promise<ValidationError[]> {
+    if (this.usingApiFallback() || this.state() !== 'ready') {
+      await this.initializeLocalMode({ allowApiFallback });
+    }
+
+    try {
+      return await this.sendMessage<ValidationError[]>('validate', {
+        sdrf: sdrfTsv,
+        templates,
+        skipOntology: options.skipOntology ?? true
+      });
+    } catch (error) {
+      if (!allowApiFallback) {
+        throw error;
+      }
+
+      console.warn('Pyodide validation failed, falling back to API:', error);
+      return this.validateWithApi(sdrfTsv, templates, options);
+    }
+  }
+
+  private async ensureApiAvailable(): Promise<void> {
+    const apiHealthy = await this.apiValidator.checkHealth();
+    this.apiAvailable.set(apiHealthy);
+
+    if (!apiHealthy) {
+      throw new Error('SDRF Validator API is not available');
+    }
+  }
+
+  private waitForLocalInitialization(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const checkReady = setInterval(() => {
+        if (this.state() === 'ready' && !this.usingApiFallback()) {
+          clearInterval(checkReady);
+          resolve();
+        } else if (this.state() === 'error') {
+          clearInterval(checkReady);
+          reject(new Error(this.lastError() || 'Initialization failed'));
+        }
+      }, 100);
+    });
   }
 }
 

--- a/src/app/core/services/sdrf-api-validator.service.ts
+++ b/src/app/core/services/sdrf-api-validator.service.ts
@@ -2,7 +2,6 @@
  * SDRF API Validator Service
  *
  * Provides SDRF validation using the EBI PRIDE SDRF Validator API.
- * This is used as a fallback when Pyodide-based validation fails.
  *
  * API Documentation: https://www.ebi.ac.uk/pride/services/sdrf-validator/docs
  */
@@ -15,7 +14,8 @@ import { ValidationError } from './pyodide-validator.service';
  */
 export interface ApiValidationError {
   message: string;
-  error_type: string;
+  type?: string;
+  error_type?: string;
   row?: number;
   column?: string;
   value?: string;
@@ -60,6 +60,20 @@ export interface ApiHealthResponse {
 }
 
 const API_BASE_URL = 'https://www.ebi.ac.uk/pride/services/sdrf-validator';
+const DEFAULT_TEMPLATES = [
+  'ms-proteomics',
+  'human',
+  'vertebrates',
+  'invertebrates',
+  'plants',
+  'cell-lines',
+];
+const TEMPLATE_ALIASES: Record<string, string> = {
+  default: 'ms-proteomics',
+  'cell_lines': 'cell-lines',
+  'cell-line': 'cell-lines',
+  'nonvertebrates': 'invertebrates',
+};
 
 export class SdrfApiValidatorService {
   readonly isAvailable = signal<boolean | null>(null);
@@ -112,12 +126,13 @@ export class SdrfApiValidatorService {
       }
 
       const result: ApiTemplatesResponse = await response.json();
-      // Extract just the template names from the objects
-      return result.templates.map(t => t.name);
+      const canonicalTemplates = result.templates.map((template) =>
+        this.normalizeTemplateName(template.name)
+      );
+      return Array.from(new Set(canonicalTemplates));
     } catch (error) {
       console.warn('Failed to get templates from API:', error);
-      // Return default templates
-      return ['default', 'human', 'vertebrates', 'nonvertebrates', 'plants', 'cell_lines'];
+      return DEFAULT_TEMPLATES;
     }
   }
 
@@ -135,11 +150,12 @@ export class SdrfApiValidatorService {
     options: { skipOntology?: boolean; useOlsCacheOnly?: boolean } = {}
   ): Promise<ValidationError[]> {
     const { skipOntology = true, useOlsCacheOnly = true } = options;
+    const normalizedTemplates = this.normalizeTemplates(templates);
 
     try {
       // Build query parameters (no content - sent via FormData)
       const params = new URLSearchParams();
-      templates.forEach(t => params.append('template', t));
+      normalizedTemplates.forEach(t => params.append('template', t));
       params.append('skip_ontology', String(skipOntology));
       params.append('use_ols_cache_only', String(useOlsCacheOnly));
 
@@ -191,11 +207,12 @@ export class SdrfApiValidatorService {
     options: { skipOntology?: boolean; useOlsCacheOnly?: boolean } = {}
   ): Promise<ValidationError[]> {
     const { skipOntology = true, useOlsCacheOnly = true } = options;
+    const normalizedTemplates = this.normalizeTemplates(templates);
 
     try {
       // Build query parameters
       const params = new URLSearchParams();
-      templates.forEach(t => params.append('template', t));
+      normalizedTemplates.forEach(t => params.append('template', t));
       params.append('skip_ontology', String(skipOntology));
       params.append('use_ols_cache_only', String(useOlsCacheOnly));
 
@@ -251,7 +268,7 @@ export class SdrfApiValidatorService {
    * Generate a suggestion based on the error type
    */
   private generateSuggestion(error: ApiValidationError): string | null {
-    const errorType = error.error_type?.toLowerCase() || '';
+    const errorType = (error.error_type || error.type || '').toLowerCase();
     const message = error.message?.toLowerCase() || '';
 
     // Common error patterns and suggestions
@@ -279,6 +296,17 @@ export class SdrfApiValidatorService {
     }
 
     return null;
+  }
+
+  private normalizeTemplates(templates: string[]): string[] {
+    const canonicalTemplates = templates.map((template) =>
+      this.normalizeTemplateName(template)
+    );
+    return Array.from(new Set(canonicalTemplates));
+  }
+
+  private normalizeTemplateName(templateName: string): string {
+    return TEMPLATE_ALIASES[templateName] || templateName;
   }
 }
 


### PR DESCRIPTION
## Summary
- prefer the deployed PRIDE SDRF validator API as the default validation backend in the SDRF editor
- keep the in-browser Pyodide validator available as an explicit local option for privacy or offline use
- normalize template aliases so the API and local validator use the same canonical template names

## Test plan
- [x] `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- [ ] `ng build` in this sandbox environment (the build process starts and is then terminated with exit code `-1` before Angular prints a diagnostic)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now switch between PRIDE API and local browser-based validation backends for SDRF validation.
  * Backend selector added to the validation interface with corresponding status updates.
  * Template handling improved with better normalization and deduplication across validation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->