### PR TITLE
Fix logo asset URLs in the embedded editor

### DIFF
--- a/src/app/components/sdrf-editor/sdrf-editor.component.ts
+++ b/src/app/components/sdrf-editor/sdrf-editor.component.ts
@@ -674,13 +674,13 @@ const BUFFER_ROWS = 10;
             <p class="footer-text">Supported by the proteomics community</p>
             <div class="partner-logos">
               <a href="https://eubic-ms.org/" target="_blank" class="partner-logo" title="EuBIC-MS">
-                <img src="assets/images/eubic-logo.png" alt="EuBIC-MS Logo" class="logo-image">
+                <img [src]="eubicLogoUrl" alt="EuBIC-MS Logo" class="logo-image">
               </a>
               <a href="https://psidev.info/" target="_blank" class="partner-logo" title="HUPO-PSI">
-                <img src="assets/images/psi-logo.png" alt="HUPO-PSI Logo" class="logo-image">
+                <img [src]="psiLogoUrl" alt="HUPO-PSI Logo" class="logo-image">
               </a>
               <a href="https://quantms.org/" target="_blank" class="partner-logo" title="QuantMS">
-                <img src="assets/images/quantms-logo.png" alt="QuantMS Logo" class="logo-image">
+                <img [src]="quantmsLogoUrl" alt="QuantMS Logo" class="logo-image">
               </a>
             </div>
           </div>
@@ -2283,6 +2283,11 @@ export class SdrfEditorComponent implements OnInit, OnChanges, AfterViewInit, On
 
   /** Current file name */
   fileName = signal('untitled.sdrf.tsv');
+
+  /** Asset URLs need to resolve relative to the loaded bundle for embedded deployments */
+  readonly eubicLogoUrl = new URL('assets/images/eubic-logo.png', import.meta.url).toString();
+  readonly psiLogoUrl = new URL('assets/images/psi-logo.png', import.meta.url).toString();
+  readonly quantmsLogoUrl = new URL('assets/images/quantms-logo.png', import.meta.url).toString();
 
   // ============ Pyodide Validation State ============
 


### PR DESCRIPTION
## Summary
- resolve the editor footer logo URLs relative to the loaded bundle instead of the host page
- fix missing EuBIC, HUPO-PSI, and QuantMS logos when `sdrfedit` is embedded from jsDelivr into `sdrf.quantms.org`
- keep same-origin deployments working by deriving the asset paths from `import.meta.url`

## Test plan
- [x] `./node_modules/.bin/tsc -p tsconfig.app.json --noEmit`
- [ ] verify the embedded editor page after deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logo image loading reliability for partner logos (EuBIC-MS, HUPO-PSI, QuantMS) in the editor to ensure proper display across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->